### PR TITLE
Add ability to delete audits from dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -238,6 +238,29 @@
             background: #5a6fd8;
         }
 
+        .action-buttons {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .delete-btn {
+            background: #dc3545;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .delete-btn:hover {
+            background: #c82333;
+        }
+
         @media (max-width: 768px) {
             .dashboard-grid {
                 grid-template-columns: 1fr;
@@ -440,17 +463,64 @@
                                         </span>
                                     </td>
                                     <td>
-                                        <a href="/?auditId=${audit.id}" class="view-audit-btn" target="_blank">
-                                            <i class="fas fa-eye"></i> View
-                                        </a>
+                                        <div class="action-buttons">
+                                            <a href="/?auditId=${audit.id}" class="view-audit-btn" target="_blank">
+                                                <i class="fas fa-eye"></i> View
+                                            </a>
+                                            <button class="delete-btn" data-audit-id="${audit.id}">
+                                                <i class="fas fa-trash"></i> Delete
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
                             `).join('')}
                         </tbody>
                     </table>
                 `;
-                
+
                 this.auditHistory.innerHTML = table;
+
+                this.auditHistory.querySelectorAll('.delete-btn').forEach(button => {
+                    button.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        this.handleDeleteAudit(button.dataset.auditId, button);
+                    });
+                });
+            }
+
+            async handleDeleteAudit(auditId, button) {
+                const confirmed = confirm('Are you sure you want to delete this audit? This action cannot be undone.');
+                if (!confirmed) {
+                    return;
+                }
+
+                const originalContent = button.innerHTML;
+                button.disabled = true;
+                button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Deleting';
+
+                this.hideMessages();
+
+                try {
+                    const response = await fetch(`/api/audit/${auditId}`, {
+                        method: 'DELETE',
+                        credentials: 'include'
+                    });
+
+                    const data = await response.json();
+
+                    if (!response.ok || !data.success) {
+                        throw new Error(data.message || 'Failed to delete audit.');
+                    }
+
+                    this.showSuccess('Audit deleted successfully.');
+                    await this.loadAuditHistory();
+                    await this.loadQuickStats();
+                } catch (error) {
+                    this.showError(error.message || 'Failed to delete audit. Please try again.');
+                } finally {
+                    button.disabled = false;
+                    button.innerHTML = originalContent;
+                }
             }
 
             async loadQuickStats() {
@@ -503,11 +573,13 @@
             showError(message) {
                 this.errorMessage.textContent = message;
                 this.errorMessage.style.display = 'block';
+                this.successMessage.style.display = 'none';
             }
 
             showSuccess(message) {
                 this.successMessage.textContent = message;
                 this.successMessage.style.display = 'block';
+                this.errorMessage.style.display = 'none';
             }
 
             hideMessages() {


### PR DESCRIPTION
## Summary
- add a delete button to each audit history row so entries can be removed from the dashboard
- wire the dashboard delete button to the existing API and refresh history and stats after removal
- make the database delete helper resilient when no database is configured or when the record is missing

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c953bb47f08325a5d4764ba5d33c13