### PR TITLE
Refine dashboard audit deletion handling

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -238,6 +238,29 @@
             background: #5a6fd8;
         }
 
+        .action-buttons {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .delete-btn {
+            background: #dc3545;
+            color: white;
+            border: none;
+            padding: 0.25rem 0.5rem;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .delete-btn:hover {
+            background: #c82333;
+        }
+
         @media (max-width: 768px) {
             .dashboard-grid {
                 grid-template-columns: 1fr;
@@ -440,17 +463,72 @@
                                         </span>
                                     </td>
                                     <td>
-                                        <a href="/?auditId=${audit.id}" class="view-audit-btn" target="_blank">
-                                            <i class="fas fa-eye"></i> View
-                                        </a>
+                                        <div class="action-buttons">
+                                            <a href="/?auditId=${audit.id}" class="view-audit-btn" target="_blank">
+                                                <i class="fas fa-eye"></i> View
+                                            </a>
+                                            <button class="delete-btn" type="button" data-audit-id="${audit.id}" data-site-url="${encodeURIComponent(audit.siteUrl)}">
+                                                <i class="fas fa-trash"></i> Delete
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
                             `).join('')}
                         </tbody>
                     </table>
                 `;
-                
+
                 this.auditHistory.innerHTML = table;
+
+                this.auditHistory.querySelectorAll('.delete-btn').forEach(button => {
+                    button.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        this.handleDeleteAudit(button.dataset.auditId, button);
+                    });
+                });
+            }
+
+            async handleDeleteAudit(auditId, button) {
+                const siteUrl = button.dataset.siteUrl ? decodeURIComponent(button.dataset.siteUrl) : '';
+                const confirmMessage = siteUrl
+                    ? `Are you sure you want to delete the audit for ${siteUrl}? This action cannot be undone.`
+                    : 'Are you sure you want to delete this audit? This action cannot be undone.';
+
+                const confirmed = confirm(confirmMessage);
+                if (!confirmed) {
+                    return;
+                }
+
+                const originalContent = button.innerHTML;
+                button.disabled = true;
+                button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Deleting';
+
+                this.hideMessages();
+
+                try {
+                    const response = await fetch(`/api/audit/${auditId}`, {
+                        method: 'DELETE',
+                        credentials: 'include'
+                    });
+
+                    const data = await response.json();
+
+                    if (!response.ok || !data.success) {
+                        throw new Error(data.message || 'Failed to delete audit.');
+                    }
+
+                    const successMessage = siteUrl
+                        ? `Audit for ${siteUrl} deleted successfully.`
+                        : 'Audit deleted successfully.';
+                    this.showSuccess(successMessage);
+                    await this.loadAuditHistory();
+                    await this.loadQuickStats();
+                } catch (error) {
+                    this.showError(error.message || 'Failed to delete audit. Please try again.');
+                } finally {
+                    button.disabled = false;
+                    button.innerHTML = originalContent;
+                }
             }
 
             async loadQuickStats() {
@@ -503,11 +581,13 @@
             showError(message) {
                 this.errorMessage.textContent = message;
                 this.errorMessage.style.display = 'block';
+                this.successMessage.style.display = 'none';
             }
 
             showSuccess(message) {
                 this.successMessage.textContent = message;
                 this.successMessage.style.display = 'block';
+                this.errorMessage.style.display = 'none';
             }
 
             hideMessages() {

--- a/src/routes/audit.js
+++ b/src/routes/audit.js
@@ -235,15 +235,29 @@ router.delete('/:auditId', requireAuth, async (req, res, next) => {
   try {
     const { auditId } = req.params;
     
-    await databaseService.deleteAudit(auditId);
-    
+    const deleted = await databaseService.deleteAudit(auditId);
+
+    if (deleted === false) {
+      return res.status(503).json({
+        success: false,
+        message: 'Audit deletion is unavailable because the database is not configured.'
+      });
+    }
+
     res.json({
       success: true,
       message: 'Audit deleted successfully'
     });
-    
+
   } catch (error) {
     logger.error('Error deleting audit:', error);
+    if (error.status === 404) {
+      return res.status(404).json({
+        success: false,
+        message: 'Audit not found'
+      });
+    }
+
     next(error);
   }
 });


### PR DESCRIPTION
## Summary
- include the audit URL in the dashboard delete confirmation and success messaging
- persist the audit URL in the delete buttons so the UI can tailor feedback per row
- return helpful API responses when deletion is unavailable or the audit is missing

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c953bb47f08325a5d4764ba5d33c13