### PR TITLE
Persist queries/pages chunk errors

### DIFF
--- a/src/services/bingScheduler.js
+++ b/src/services/bingScheduler.js
@@ -8,6 +8,51 @@ const SEARCH_TYPES = ['web']; // Bing primarily uses 'web' search type
 
 function iso(d) { return d.toISOString().slice(0,10); }
 
+async function persistSyncStatus(siteUrl, searchType, options) {
+  const {
+    status,
+    message = null,
+    dimension = 'page',
+    lastSyncedDate,
+    lastRunAt,
+  } = options;
+
+  const now = lastRunAt ?? new Date();
+  const hasLastSyncedDate = Object.prototype.hasOwnProperty.call(options, 'lastSyncedDate');
+
+  const updateData = {
+    lastRunAt: now,
+    status,
+    message,
+  };
+
+  if (hasLastSyncedDate) {
+    updateData.lastSyncedDate = lastSyncedDate;
+  }
+
+  const createData = {
+    siteUrl,
+    searchType,
+    dimension,
+    lastSyncedDate: hasLastSyncedDate ? lastSyncedDate : null,
+    lastRunAt: now,
+    status,
+    message,
+  };
+
+  await databaseService.prisma.bingSyncStatus.upsert({
+    where: {
+      siteUrl_searchType_dimension: {
+        siteUrl,
+        searchType,
+        dimension,
+      },
+    },
+    update: updateData,
+    create: createData,
+  });
+}
+
 async function acquireLock(lockId, ttlMs, who) {
   const now = new Date();
   const until = new Date(now.getTime() + ttlMs);
@@ -608,30 +653,10 @@ class BingScheduler {
           processedChunks++;
           consecutiveErrors = 0;
 
-          const now = new Date();
-          await databaseService.prisma.bingSyncStatus.upsert({
-            where: {
-              siteUrl_searchType_dimension: {
-                siteUrl,
-                searchType,
-                dimension: 'page',
-              },
-            },
-            update: {
-              lastSyncedDate: chunkEnd,
-              lastRunAt: now,
-              status: 'ok',
-              message: null,
-            },
-            create: {
-              siteUrl,
-              searchType,
-              dimension: 'page',
-              lastSyncedDate: chunkEnd,
-              lastRunAt: now,
-              status: 'ok',
-              message: null,
-            },
+          await persistSyncStatus(siteUrl, searchType, {
+            status: 'ok',
+            lastSyncedDate: chunkEnd,
+            message: null,
           });
 
           logger.info(`Bing Scheduler: Queries/pages chunk ${chunk + 1} completed for ${siteUrl} - Queries: ${results.results?.queries?.recordsProcessed || 0}, Pages: ${results.results?.pages?.recordsProcessed || 0}`);
@@ -650,6 +675,21 @@ class BingScheduler {
           if (consecutiveErrors >= maxConsecutiveErrors) {
             logger.error(`Bing Scheduler: Too many consecutive errors (${consecutiveErrors}), stopping queries/pages sync for ${siteUrl}`);
             break;
+          }
+
+          try {
+            const baseMsg =
+              (chunkError && typeof chunkError.message === 'string')
+                ? chunkError.message
+                : String(chunkError);
+            // Include failing range and cap size to protect DB column
+            const errMessage = (`[${iso(chunkStart)}..${iso(chunkEnd)}] ${baseMsg}`).slice(0, 1024);
+            await persistSyncStatus(siteUrl, searchType, {
+              status: 'error',
+              message: errMessage,
+            });
+          } catch (statusPersistError) {
+            logger.warn(`Bing Scheduler: Failed to persist queries/pages error status for ${siteUrl}: ${statusPersistError.message}`);
           }
 
           const backoffDelay = Math.min(1000 * Math.pow(2, consecutiveErrors), 10000);


### PR DESCRIPTION
## Summary
- update processQueriesAndPages error handling to record chunk failures in bingSyncStatus with normalized capped messages including the chunk range
- refactor bing sync status persistence into a helper to reduce duplication
- warn when persisting the error status fails but continue with existing retry logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf8f2288988325968d7be8ed28949b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More descriptive Bing sync status messages, including date ranges for failures.

- Bug Fixes
  - Improved error handling to prevent sync interruptions when saving status fails.
  - More resilient processing for partial failures during chunked syncs.

- Chores
  - Tuned sync scheduling for faster, more frequent updates (smaller date chunks, shorter delays).
  - Capped error message length to ensure reliable status storage and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->